### PR TITLE
Group-ownership-cannot-be-set

### DIFF
--- a/src/PattyServer.js
+++ b/src/PattyServer.js
@@ -80,16 +80,6 @@ class PattyServer {
     // no target user to switch to
     if (!this.options.processOwner) { return; }
 
-    // set user-id
-    // nothing to do for non-posix system
-    if (!process.setuid) { return; }
-    try {
-      process.setuid(this.options.processOwner);
-    } catch(e) {
-      // throw PattyError.other()
-      this.logError(`Could not change process owner to "${this.options.processOwner}"`, e);
-    }
-
     // set group-id
     // nothing to do for non-posix system
     if (!process.setgid) { return; }
@@ -100,6 +90,16 @@ class PattyServer {
     } catch(e) {
       // throw PattyError.other()
       this.logError(`Could not change process owner group to "${gid}"`, e);
+    }
+
+    // set user-id
+    // nothing to do for non-posix system
+    if (!process.setuid) { return; }
+    try {
+      process.setuid(this.options.processOwner);
+    } catch(e) {
+      // throw PattyError.other()
+      this.logError(`Could not change process owner to "${this.options.processOwner}"`, e);
     }
   }
 


### PR DESCRIPTION
The issue roots from the fact that we do uid de-escalation before setting gid. Since the process owner is no more root, the group id cannot be set and the following error message is logged in the logs:


```
2021-07-06 10:09:04.589 ERROR Could not change process owner group to "1001" [because] EPERM, Operation not permitted
2021-07-06 10:09:04.589 ERROR Error: Could not change process owner group to "1001"
```

