### PR TITLE
LKE-13386: Set UID/GID when spawning the server

### DIFF
--- a/src/Patty.js
+++ b/src/Patty.js
@@ -308,7 +308,7 @@ class Patty {
           });
         } else {
           // console.log('(started:no, installed:no) spawning server');
-          p = PattyServer.spawn(this.home).catch(err => {
+          p = PattyServer.spawn(this.home, this.options).catch(err => {
             this._logger.error('Manager launch failed', err);
             return Promise.reject(err);
           });

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -328,6 +328,18 @@ class Utils {
   }
 
   /**
+   * Get the UserID of a user.
+   *
+   * @param {string} username
+   * @returns {Promise<number|undefined>}
+   */
+  static async getUID(username) {
+    const r = await Utils.exec(`id -u "${username}"`);
+    const uid = parseInt(r.out);
+    return Number.isNaN(uid) ? undefined : uid;
+  }
+
+  /**
    * Get the GroupID of a user.
    *
    * @param {string} username


### PR DESCRIPTION
https://linkurious.atlassian.net/browse/LKE-13386

Fix the issue described in https://linkurious.atlassian.net/browse/LKE-13386?focusedCommentId=59679

# How to reproduce

* As the root user
* I download and unzip Linkurious in a folder (let's say for instance in `/opt/linkurious-linux`).
* I create a dedicated Linkurious account, and give it ownership of the Linkurious folder:
 
```
useradd -r linkurious
chown -R linkurious:linkurious /opt/linkurious-linux
```

* I start Linkurious (as the root user):

```
cd /opt/linkurious-linux
./start.sh
```

 :bug: The manager server fails to start. :bug: 

# What's going on?

* The `start.sh` script calls the `menu.sh` one.
* This one correctly detects that it has been called by the root user, and thus calls the `manager.js` script with the `--user=linkurious` option.
* The problem is internal to PattyPM: when it spawns its server, it does not define the `uid` / `gid` of the process. Its intent is to set them after the process has been started.
* This does not work because the server logger is initialized before the `uid` / `gid` have been changed. So the manager log file is created with root as its owner. And the next log message printed after the  `uid` / `gid` have been changed causes the server process to crash:

https://github.com/Linkurious/pattypm/blob/d65e0732192284179acf6aa7068a8b70c66024a1/src/PattyServer.js#L141

# What's the fix?

We directly set the `uid` / `gid` when the server process is spawned.

There "could be" a possible drawback with that solution: if the `uid` or the `gid` cannot be set, the server process will fail to spawn. Before, we would just log an error and resume execution: In any case, this would have been bound to fail, as the `uid` / `gid` must be set before the logger is initialized. In a nutshell, failing to set the `uid` / `gid` is a fatal error: there is no point in trying to recover from it.