### PR TITLE
Add public publishConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   "license": "MIT",
   "version": "1.0.39",
   "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
Add a publishConfig section with "access": "public" to package.json so the package will be published with public visibility 