### PR TITLE
add scope for pattypm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,14 @@ A Process Manager called Patty
 
 ![](http://assets.amuniversal.com/8b7f3740b0da012f2fef00163e41dd5b)
 see http://dilbert.com/strip/1999-04-18
+
+## ⚠️ Breaking change: scoped under @linkurious
+
+From 2026-05, this package has been renamed from `pattypm` to `@linkurious/pattypm`.
+
+Existing users should update their dependency:
+
+```bash
+npm uninstall pattypm
+npm install @linkurious/pattypm
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pattypm",
+  "name": "@linkurious/pattypm",
   "version": "1.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pattypm",
+      "name": "@linkurious/pattypm",
       "version": "1.0.39",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pattypm",
+  "name": "@linkurious/pattypm",
   "description": "A truly cross-platform process manager",
   "repository": {
     "type": "git",


### PR DESCRIPTION
OPS-2787: need a scoping of the npm registry for public publish from the ci.
