### PR TITLE
LKE-15182: Fix service uninstallation on Windows

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -570,7 +570,7 @@ class Utils {
    * @return void
    */
   static removeSync(filePath) {
-    fs.rmSync(filePath);
+    fs.rmSync(filePath, {recursive: true});
   }
 
   /**

--- a/test/TestUtils.js
+++ b/test/TestUtils.js
@@ -90,8 +90,8 @@ const TestUtils = {
 
   cleanUp: (configFilePath) => {
     try {
-      fs.rmSync(path.resolve(__dirname, 'logs'));
-      fs.rmSync(configFilePath);
+      Utils.removeSync(path.resolve(__dirname, 'logs'));
+      Utils.removeSync(configFilePath);
     } catch(e) {
       // no op
     }


### PR DESCRIPTION
https://linkurious.atlassian.net/browse/LKE-15182

In https://github.com/Linkurious/pattypm/pull/58, we replaced `fs-extra` by the native `node:fs`.

In `WindowsSystem.js`, there was a call to `fsExtra.removeSync(path)`. It was replaced by a call to `nodeFs.rmSync(path)`. The problem is that the former recursively deletes directories, and the latter does not, unless the `{recursive: true}` option is specified.

The consequence is the following one: on Windows, if one tries to uninstall Linkurious as a service, the following happens:
* PattyPM first calls the Windows service manager to uninstall the daemon. This operation completes.
* PattyPM then deletes the config directory of the daemon. This fails due to the missing `{recursive: true}` option:

```
Could not uninstall linkurious from system services because Path is a directory: rm returned EISDIR (is a directory) ...
```

---

The problem is that PattyPM assumes Linkurious is still installed as a service, because the config directory of the daemon has not been deleted. And we get stuck:
* PattyPM assumes Linkurious is already installed as a service, so the install operation does nothing.
* The uninstall always fails due to the node fs EISDIR error.
* Starting Linkurious do not work either because, the daemon silently fails to start (it does not exist). So the PattyPM client incorrectly assumes the daemon is started, but fails to connect: `ECONNREFUSED 127.0.0.1:5891`.

---

Hopefully, the workaround is an easy one: just manually delete the daemon folder.