### PR TITLE
LKE-15182: Fix service uninstallation on Windows - episode 2

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -565,15 +565,6 @@ class Utils {
   }
 
   /**
-   * Remove a file
-   * @param filePath
-   * @return void
-   */
-  static removeSync(filePath) {
-    fs.rmSync(filePath, {recursive: true});
-  }
-
-  /**
    * Returns a promise resolved in `ms` milliseconds.
    * @param ms
    * @returns {Promise<void>}

--- a/src/system/WindowsSystem.js
+++ b/src/system/WindowsSystem.js
@@ -205,8 +205,8 @@ class WindowsSystem extends System {
    * @private
    */
   _deleteDaemon() {
-    Utils.removeSync(this._daemonPath);
-    return Promise.resolve();
+    return WindowsSystem.runElevated('cmd.exe', ['/c', 'rmdir', '/s', '/q', this._daemonPath])
+      .then(() => Utils.resolveIn(1000));
   }
 
   /**

--- a/test/TestUtils.js
+++ b/test/TestUtils.js
@@ -90,8 +90,8 @@ const TestUtils = {
 
   cleanUp: (configFilePath) => {
     try {
-      Utils.removeSync(path.resolve(__dirname, 'logs'));
-      Utils.removeSync(configFilePath);
+      fs.rmSync(path.resolve(__dirname, 'logs'), {recursive: true});
+      fs.rmSync(configFilePath);
     } catch(e) {
       // no op
     }


### PR DESCRIPTION
https://linkurious.atlassian.net/browse/LKE-15182

Follow up https://github.com/Linkurious/pattypm/pull/76

# Problem

When I tested the fix, on a Windows server instance, it looked like it was working correctly.

However, Xavier tried on his Windows laptop, and consistently encountered `EPERM` errors on the removal of the daemon directory.

In any case, the daemon directory is created without elevation. But the service then runs with elevation. According to Claude:

> _When `winsw install` (elevated) registers the service and the service then runs, the `winsw` process executes its own image — `daemon\linkurious-windows.exe` — as SYSTEM. A running executable image being loaded by a SYSTEM process is enough to make deletion require elevation, and depending on the `winsw` version it can also touch/rewrite files next to the exe as SYSTEM, changing their owner/ACLs from your user to SYSTEM/Administrators._

It seems pretty plausible. The account I was using on Windows server was an admin, I guess that's why I didn't have the permission error.

# Solution

Replace `fs.rmSync` by a native `rmdir`, running with elevation. We've tested it on Xavier's laptop, it works fine.